### PR TITLE
Don't emit an empty error string.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.70"
+channel = "stable"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.70"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/src/actions/update.rs
+++ b/src/actions/update.rs
@@ -31,7 +31,10 @@ pub async fn update_tools(
                 }
                 progress_bar.inc(1);
             }
-            error!("{}", failed_tools.join("\n"));
+
+            if !failed_tools.is_empty() {
+                error!("{}", failed_tools.join("\n"));
+            }
 
             Ok(())
         }
@@ -44,11 +47,15 @@ pub async fn update_tools(
             } else {
                 None
             };
-            if let Some(tool) = tools.iter().find(|t| t.name == split_name[0]) {
-                info!("Tool: {:?}", tool);
+
+            if let Some(tool) = tools
+                .iter()
+                .find(|t| t.name == split_name[0] || t.alias == split_name[0])
+            {
+                info!("Updating: {:?}", tool);
 
                 match super::handle_tool_install(env, tool, system, version).await {
-                    Ok(_) => info!("Tool {} has been updated.", &tool.name),
+                    Ok(_) => info!("{} has been updated.", &tool.name),
                     Err(install_err) => error!("{:?}", install_err),
                 }
             } else {

--- a/src/download.rs
+++ b/src/download.rs
@@ -46,13 +46,15 @@ pub async fn download_asset<P: Into<PathBuf>>(
     };
     match reqwest::get(asset.browser_download_url.as_str()).await {
         Ok(download_result) => match download_result.bytes().await {
-            Ok(download_bytes) => match async_std::fs::write(&out_file_name, download_bytes).await {
-                Ok(_) => Ok(out_file_name),
-                Err(write_err) => Err(DownloadError::FileWrite {
-                    file_path: out_file_name,
-                    source: write_err,
-                }),
-            },
+            Ok(download_bytes) => {
+                match async_std::fs::write(&out_file_name, download_bytes).await {
+                    Ok(_) => Ok(out_file_name),
+                    Err(write_err) => Err(DownloadError::FileWrite {
+                        file_path: out_file_name,
+                        source: write_err,
+                    }),
+                }
+            }
             Err(bytes_err) => Err(DownloadError::ResponseBytes(bytes_err)),
         },
         Err(down_err) => Err(DownloadError::HttpGet {


### PR DESCRIPTION
Allow matching the tool repo/alias as well as <author>/<repo>

Use 'stable' as the Rust version.